### PR TITLE
adjust Debian and Go versions in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,23 +6,29 @@ on:
   pull_request:
     branches: [ main ]
 
-jobs:
+env:
+    GOPROXY: direct
+    GOVCS: private:all,public:all
+    CGO_ENABLED: 1
 
+jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+        debian:buster
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: '1.20'
 
     - name: Get dependencies
       run: |
-        go get -v -t -d ./...
-        sudo apt-get install -y libzmq3-dev
-
+        apt-get update
+        apt-get install -y git build-essential pkg-config bzr libzmq3-dev
+        go get -v -t ./...
         if [ -f Gopkg.toml ]; then
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/TcM1911/stix2 v0.6.1-0.20201122154655-049b8a26ae97
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/jarcoal/httpmock v1.3.1 // indirect
-	github.com/pebbe/zmq4 v1.2.5
+	github.com/pborman/uuid v1.2.1 // indirect
+	github.com/pebbe/zmq4 v1.2.10
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9
 	github.com/ugorji/go v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwU
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pebbe/zmq4 v1.2.5 h1:ygTu6F/sMp7TIo7JN/ObpotHudy7+Rnun1LLSybyCFs=
 github.com/pebbe/zmq4 v1.2.5/go.mod h1:3+LG+02U+ToKtxF9avLo17NGTVDhWtRhsdU3spikK8o=
+github.com/pebbe/zmq4 v1.2.10 h1:wQkqRZ3CZeABIeidr3e8uQZMMH5YAykA/WN0L5zkd1c=
+github.com/pebbe/zmq4 v1.2.10/go.mod h1:nqnPueOapVhE2wItZ0uOErngczsJdLOGkebMxaO8r48=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=


### PR DESCRIPTION
We would like to get a binary that runs on older distributions than `ubuntu-latest` ;)
It also makes sense to bump the Go version we build with to something newer than 1.15.